### PR TITLE
Removed hardcoded mapbox.com URL from RSS item

### DIFF
--- a/_includes/rss-item.xml
+++ b/_includes/rss-item.xml
@@ -1,6 +1,6 @@
 <item>
   <title>{{item.title | xml_escape}}</title>
-  <link>http://mapbox.com{{item.url}}</link>
+  <link>{{site.baseurl}}{{item.url}}</link>
   <description>{{item.content | markdownify | xml_escape}}</description>
   <pubDate>{{item.date | date_to_xmlschema}}</pubDate>
   <dc:creator>SITE NAME</dc:creator>


### PR DESCRIPTION
I personally used `{{site.prose.siteurl}}` in my project though to make things work smoothly both locally and live.
