### PR TITLE
default should no carry a title: because it overwrites...

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,3 @@
----
-title: 'This is my Site Title'
----
 <!DOCTYPE html>
 <html>
 <head>
@@ -21,7 +18,7 @@ title: 'This is my Site Title'
             <a class='{% if page.url == "about/" %}active{% endif %}' href='{{site.baseurl}}/about'>About</a>
             <a href='//github.com/prose/starter'>Fork on GitHub</a>
           </div>
-          <h1 class='title'><a href='{{site.baseurl}}/'>{{page.title}}</a></h1>
+          <h1 class='title'><a href='{{site.baseurl}}/'>Site Title</a></h1>
         </div>
       </div>
     </div>


### PR DESCRIPTION
default should no carry a title: because it overwrites the `<title>` tag and makes it static instead of change it based in the current page title.

Besides having 2 `<h1>` elements in the same page, the website title or logo should be a static content, not based in the variable of the current page
