### PR TITLE
Remove slash from splash image URL

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -7,7 +7,7 @@ section: blog
   {% if page.splash contains 'http' %}
     {% capture url %}{{page.splash}}{% endcapture %}
   {% else %}
-    {% capture url %}{{site.baseurl}}{{page.splash}}/{% endcapture %}
+    {% capture url %}{{site.baseurl}}{{page.splash}}{% endcapture %}
   {% endif %}
 
   <div class='col12 splash'>


### PR DESCRIPTION
Remove slash from splash image URL as if it is an external URL it would have it if needed and if it is an image in the local directories it can't end in an `slash`
