### PR TITLE
Add '/' to starter localhost URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Starter is a barebones starting point for responsive sites built on Jekyll and with
 site management in [prose](http://prose.io). To get started, Fork this repo and [install Jekyll](http://jekyllrb.com/docs/installation).
 
-To work on the site locally, run `jekyll serve --watch`, then visit `http://localhost:4000/starter` in your browser.
+To work on the site locally, run `jekyll serve --watch`, then visit `http://localhost:4000/starter/` in your browser.
 
 If you notice any problems or would like to contribute to the project start a discussion from the [issues page](https://github.com/prose/starter/issues)


### PR DESCRIPTION
visiting localhost:4000/starter for me resulted in an error, while localhost:4000/starter/ worked.
